### PR TITLE
Fix padding for publication list

### DIFF
--- a/library/css/components/publication-list.css
+++ b/library/css/components/publication-list.css
@@ -1,9 +1,12 @@
+.ui.publication-list {
+  padding-top: 1.5rem;
+}
 .ui.publication-list > .list-item {
   width: 100%;
-  padding: 1.5rem;
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
   line-height: 1.5rem;
   box-sizing: border-box;
-  padding-bottom: 0;
   /* font-family: 'Nunito Sans'; */
 }
 .ui.publication-list > .list-item .head {


### PR DESCRIPTION
Fixed padding so that padding above and below the list item is same.
<img width="1432" alt="Screenshot 2021-11-29 at 10 19 47 PM" src="https://user-images.githubusercontent.com/54406059/143909103-2907e2e2-1148-4c38-811f-7d4b7ddebcc5.png">


