### PR TITLE
Remove extra wrapping div from carousel component

### DIFF
--- a/library/css/components/carousel.css
+++ b/library/css/components/carousel.css
@@ -2,10 +2,11 @@
   position: relative;
 }
 
-.ui.carousel > .carousel-image {
+.ui.carousel > .ui.image {
   display: none;
 }
-.ui.carousel > .carousel-image > .ui.image > .numbertext {
+
+.ui.carousel > .ui.image > .numbertext {
   color: #f2f2f2;
   font-size: 0.75rem;
   padding: 0.5rem 0.75rem;
@@ -13,7 +14,7 @@
   top: 0.5rem;
 }
 
-.ui.carousel > .carousel-image > .image.fluid > img {
+.ui.carousel > .image.fluid > img {
   width: 100%;
   height: 40vw;
 }
@@ -73,7 +74,7 @@
 }
 
 /* Fading animation */
-.ui.carousel > .carousel-image > .fade {
+.ui.carousel > .ui.image.fluid {
   -webkit-animation-name: fade;
   -webkit-animation-duration: 1.5s;
   animation-name: fade;

--- a/library/javascript/components/carousel.js
+++ b/library/javascript/components/carousel.js
@@ -1,11 +1,34 @@
 var slideIndex = 1;
-var slides = document.querySelectorAll(".carousel-image");
+var slides = document.querySelectorAll(".ui.image");
+generateNavigator()
 generateDots(slides.length);
 showSlides(slideIndex);
 generateNumber(slides.length);
 
+// This function adds the navigator arrows to the carousel
+function generateNavigator() {
+    var carousel = document.querySelector('.ui.carousel')
+    var flexbox = document.createElement('div')
+    flexbox.classList.add('ui')
+    flexbox.classList.add('flexbox')
+    var prevArrow = document.createElement('a')
+    prevArrow.classList.add('prev')
+    prevArrow.onclick = function() { plusSlides(-1) }
+    prevArrow.innerHTML='&#10094;'
+    flexbox.appendChild(prevArrow)
+    var nextArrow = document.createElement('a')
+    nextArrow.classList.add('next')
+    nextArrow.onclick = function() { plusSlides(1) }
+    nextArrow.innerHTML='&#10095;'
+    flexbox.appendChild(nextArrow)
+    carousel.appendChild(flexbox)
+}
+
 function generateDots(count){
-    var dotContainer = document.querySelector('.dot-container');
+    var carousel = document.querySelector('.ui.carousel')
+    dotContainer = document.createElement('div')
+    dotContainer.classList.add('dot-container')
+    carousel.appendChild(dotContainer)
     for (var i=1; i<=count; i++){
         var ele = document.createElement('span');
         ele.classList.add('dot');

--- a/test/components/carousel.html
+++ b/test/components/carousel.html
@@ -12,31 +12,18 @@
     <hr />
 
     <div class="ui carousel">
-      <div class="carousel-image">
-        <div class="ui image fluid fade">
+        <div class="ui image fluid">
           <img src="https://www.iitr.ac.in/Main/assets/images/DSC_1967.jpeg" alt="image" />
         </div>
-      </div>
-      <div class="carousel-image">
-        <div class="ui image fluid fade">
+        <div class="ui image fluid">
           <img src="https://www.iitr.ac.in/Main/assets/images/DSC_2166_cropped.jpeg" alt="image" />
         </div>
-      </div>
-      <div class="carousel-image">
-        <div class="ui image fluid fade">
-          <img src="https://www.iitr.ac.in/Main/assets/images/carousel3.jpg" alt="image" />
+        <div class="ui image fluid">
+          <img src="https://www.iitr.ac.in/Main/assets/images/DSC_1967.jpeg" alt="image" />
         </div>
-      </div>
-      <div class="carousel-image">
-        <div class="ui image fluid fade">
+        <div class="ui image fluid">
           <img src="	https://www.iitr.ac.in/Main/assets/images/carousel1.png" alt="image" />
         </div>
-      </div>
-      <div class="ui flexbox">
-        <a class="prev" onclick="plusSlides(-1)">&#10094;</a>
-        <a class="next" onclick="plusSlides(1)">&#10095;</a>
-      </div>
-      <div class="dot-container"></div>
     </div>
   </body>
   <script src="../../library/javascript/components/carousel.js"></script>


### PR DESCRIPTION
Carousel had an extra div wrapping around every image (which wasn't needed). This PR removes it to make transpilation and generation interface simpler.