### PR TITLE
Fix menu hover bug by changing section heading z-index

### DIFF
--- a/library/css/components/carousel.css
+++ b/library/css/components/carousel.css
@@ -97,7 +97,7 @@
   width: 50%;
   height: 10%;
   word-wrap: normal;
-  z-index: 5;
+  z-index: 4;
   overflow: hidden;
   font-weight: 1000;
   font-family: serif;


### PR DESCRIPTION
Reduces z-index of redundant carousel section heading divs , which fixes the interaction bug between menuitem and carousel. Should have little to no impact on the carousel component itself considering section-headings are empty by default.