### PR TITLE
fix: remove page reload on window resize in slider component

### DIFF
--- a/library/javascript/components/slider.js
+++ b/library/javascript/components/slider.js
@@ -1,27 +1,24 @@
-var src = "https://cmsredesign.channeli.in/"
-const rightArrow = src + "library/assets/icons/carouselright.svg"
-const leftArrow = src + "library/assets/icons/carouselleft.svg"
+var src = "https://cmsredesign.channeli.in/";
+const rightArrow = src + "library/assets/icons/carouselright.svg";
+const leftArrow = src + "library/assets/icons/carouselleft.svg";
 
 // Hash function
 // Returns a hash of argument length
 function makeHash(length) {
-  let result = ""
+  let result = "";
   const characters =
-    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
-  const charactersLength = characters.length
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  const charactersLength = characters.length;
   for (let i = 0; i < length; i++) {
-    result += characters.charAt(Math.floor(Math.random() * charactersLength))
+    result += characters.charAt(Math.floor(Math.random() * charactersLength));
   }
-  return result
+  return result;
 }
-let intervalID
-
+let intervalID;
 
 // THIS FUNCTION REORDERS SLIDES by either inserting the last slide to first or
 // first slide to last
 const reorderSlides = (sliderHash, numCards, isLeft) => {
-  
-
   const sliderElement = document.getElementById(sliderHash);
   const container = sliderElement.getElementsByClassName("container")[0];
   const cards = container.children;
@@ -39,68 +36,55 @@ const reorderSlides = (sliderHash, numCards, isLeft) => {
   let currentPosition = 0;
   let newPosition = currentPosition + animationStep;
 
-  const animationDuration = 700; 
+  const animationDuration = 700;
   const framesPerSecond = 60;
   const totalFrames = Math.ceil(animationDuration / (700 / framesPerSecond));
   const frameStep = animationStep / totalFrames;
   let animationStopped = false; // Flag to track animation state
 
-  
-
   const animate = () => {
     if (!animationStopped) {
-    currentPosition += frameStep;
-    container.style.transform = `translateX(${currentPosition}px)`;
-    
-  
+      currentPosition += frameStep;
+      container.style.transform = `translateX(${currentPosition}px)`;
 
-
-    if (Math.abs(currentPosition) >= Math.abs(animationStep)) {
-     
-      if (isLeft) {
-
-           if (totalNumberOfCards <= numCards) {
-      return
-    }
-    if (totalNumberOfCards > numCards) {
-      cards[numCards - 1].style.display = "none"
-    }
-    const lastCard = cards[totalNumberOfCards - 1]
-    if (lastCard.classList.contains("image-description-card")) {
-      lastCard.style.display = "flex"
-    } else {
-      lastCard.style.display = "block"
-    }
-    container.insertBefore(lastCard, container.firstChild)
-        
-
-        
-      } else {
-        if (totalNumberOfCards <= numCards) {
-          return
-        }
-        // Put first card to the bottom
-        const firstChild = cards[0]
-        if (totalNumberOfCards > numCards) {
-          firstChild.style.display = "none"
-        }
-        cards[numCards].style.display = "block"
-        if (cards[numCards].classList.contains("image-description-card")) {
-          cards[numCards].style.display = "flex"
+      if (Math.abs(currentPosition) >= Math.abs(animationStep)) {
+        if (isLeft) {
+          if (totalNumberOfCards <= numCards) {
+            return;
+          }
+          if (totalNumberOfCards > numCards) {
+            cards[numCards - 1].style.display = "none";
+          }
+          const lastCard = cards[totalNumberOfCards - 1];
+          if (lastCard.classList.contains("image-description-card")) {
+            lastCard.style.display = "flex";
+          } else {
+            lastCard.style.display = "block";
+          }
+          container.insertBefore(lastCard, container.firstChild);
         } else {
-          cards[numCards].style.display = "block"
+          if (totalNumberOfCards <= numCards) {
+            return;
+          }
+          // Put first card to the bottom
+          const firstChild = cards[0];
+          if (totalNumberOfCards > numCards) {
+            firstChild.style.display = "none";
+          }
+          cards[numCards].style.display = "block";
+          if (cards[numCards].classList.contains("image-description-card")) {
+            cards[numCards].style.display = "flex";
+          } else {
+            cards[numCards].style.display = "block";
+          }
+          container.appendChild(firstChild);
         }
-        container.appendChild(firstChild)
-        
-      
-      }
-      container.style.transform = "translateX(0)";
-      currentPosition = 0;
+        container.style.transform = "translateX(0)";
+        currentPosition = 0;
         animationStopped = true; // Pause animation after completing a cycle
-       
-      
-      return;
-    }
+
+        return;
+      }
     }
 
     if (Math.abs(currentPosition) < Math.abs(animationStep)) {
@@ -109,209 +93,171 @@ const reorderSlides = (sliderHash, numCards, isLeft) => {
   };
 
   animate();
-  
 };
 
 const renderSlides = (hash, numberOfCards) => {
-  const sliderElement = document.getElementById(hash)
-  const container = sliderElement.getElementsByClassName("container")[0]
-  const cards = container.children
+  const sliderElement = document.getElementById(hash);
+  const container = sliderElement.getElementsByClassName("container")[0];
+  const cards = container.children;
   for (let i = 0; i < cards.length; ++i) {
     if (i < numberOfCards) {
       if (cards[i].classList.contains("image-description-card")) {
-        cards[i].style.display = "flex"
+        cards[i].style.display = "flex";
       } else {
-        cards[i].style.display = "block"
+        cards[i].style.display = "block";
       }
-    } else cards[i].style.display = "none"
+    } else cards[i].style.display = "none";
   }
-}
+};
 
 // FUNCTION TO CALCULATE THE NUMBER OF CARDS
 
 const numberOfCardsToDisplay = (sliderHash) => {
-  const sliderElement = document.getElementById(sliderHash)
+  const sliderElement = document.getElementById(sliderHash);
 
   const vw = Math.max(
     document.documentElement.clientWidth || 0,
     window.innerWidth || 0
-  )
-  const px = Math.ceil((vw * 10) / 100)
+  );
+  const px = Math.ceil((vw * 10) / 100);
 
-  const container = sliderElement.getElementsByClassName("container")[0]
+  const container = sliderElement.getElementsByClassName("container")[0];
   // Handle the case when the slider has no cards
   if (container.children.length === 0) {
-    return 0
+    return 0;
   }
-  const card = container.firstElementChild
+  const card = container.firstElementChild;
   const numberOfCards = Math.floor(
     (sliderElement.clientWidth - px) / card.offsetWidth
-  )
-  const ret = numberOfCards > 1 ? numberOfCards : 1
-  return ret
-}
+  );
+  const ret = numberOfCards > 1 ? numberOfCards : 1;
+  return ret;
+};
 
-const sliderMap = {}
-
+const sliderMap = {};
 
 window.addEventListener("load", function (e) {
-  const sliders = document.querySelectorAll(".ui.slider")
+  const sliders = document.querySelectorAll(".ui.slider");
   for (let i = 0; i < sliders.length; ++i) {
-    const hash = makeHash(10)
-    sliders[i].id = hash
-    sliderMap[hash] = 1
-    const outerContainer = document.createElement("div")
-    outerContainer.className = "outer-container"; 
+    const hash = makeHash(10);
+    sliders[i].id = hash;
+    sliderMap[hash] = 1;
+    const outerContainer = document.createElement("div");
+    outerContainer.className = "outer-container";
 
-    const container = document.createElement("div")
-    container.className = "container"
-   
-    let card = sliders[i].firstChild
+    const container = document.createElement("div");
+    container.className = "container";
+
+    let card = sliders[i].firstChild;
 
     while (card) {
-      container.appendChild(card)
-      card = sliders[i].firstChild
+      container.appendChild(card);
+      card = sliders[i].firstChild;
     }
-    
 
+    const leftArrowContainer = document.createElement("div");
+    leftArrowContainer.className = "left-arrow-container";
+    container.className = "container";
 
-    const leftArrowContainer = document.createElement("div")
-    leftArrowContainer.className = "left-arrow-container"
-    container.className = "container"
-    
+    const leftArrowElement = document.createElement("img");
+    leftArrowElement.className = "arrow";
+    leftArrowElement.setAttribute("src", leftArrow);
+    leftArrowContainer.appendChild(leftArrowElement);
 
-    const leftArrowElement = document.createElement("img")
-    leftArrowElement.className = "arrow"
-    leftArrowElement.setAttribute("src", leftArrow)
-    leftArrowContainer.appendChild(leftArrowElement)
+    const rightArrowContainer = document.createElement("div");
+    rightArrowContainer.className = "right-arrow-container";
 
-    const rightArrowContainer = document.createElement("div")
-    rightArrowContainer.className = "right-arrow-container"
+    const rightArrowElement = document.createElement("img");
+    rightArrowElement.className = "arrow";
+    rightArrowElement.setAttribute("src", rightArrow);
+    rightArrowContainer.appendChild(rightArrowElement);
+    outerContainer.appendChild(container);
 
-    const rightArrowElement = document.createElement("img")
-    rightArrowElement.className = "arrow"
-    rightArrowElement.setAttribute("src", rightArrow)
-    rightArrowContainer.appendChild(rightArrowElement)
-    outerContainer.appendChild(container) 
-
-    sliders[i].appendChild(leftArrowContainer)
+    sliders[i].appendChild(leftArrowContainer);
     // sliders[i].appendChild(container)
     sliders[i].appendChild(outerContainer);
-    sliders[i].appendChild(rightArrowContainer)
-    
-    
+    sliders[i].appendChild(rightArrowContainer);
+
     leftArrowElement.addEventListener("click", function (e) {
-      e.stopPropagation()
-      e.preventDefault()
+      e.stopPropagation();
+      e.preventDefault();
 
       if (e.target) {
-        reorderSlides(hash, sliderMap[hash], false)
+        reorderSlides(hash, sliderMap[hash], false);
         clearInterval(intervalID);
-
-   
       }
-    })
+    });
 
     rightArrowElement.addEventListener("click", function (e) {
-      e.stopPropagation()
-      e.preventDefault()
+      e.stopPropagation();
+      e.preventDefault();
 
       if (e.target) {
-        reorderSlides(hash, sliderMap[hash], true)
+        reorderSlides(hash, sliderMap[hash], true);
         clearInterval(intervalID);
-       
-    
-    
       }
-    })
-   
+    });
 
-   
-  
-   
-
-    images = container.querySelectorAll("img")
-    loadedImageCounter = 0
+    images = container.querySelectorAll("img");
+    loadedImageCounter = 0;
     images.forEach(function (image) {
       image.addEventListener("load", function (e) {
-        loadedImageCounter++
+        loadedImageCounter++;
         if (loadedImageCounter == images.length) {
-          renderSlides(hash, sliderMap[hash])
-          sliderMap[hash] = numberOfCardsToDisplay(hash)
-          renderSlides(hash, sliderMap[hash])
+          renderSlides(hash, sliderMap[hash]);
+          sliderMap[hash] = numberOfCardsToDisplay(hash);
+          renderSlides(hash, sliderMap[hash]);
         }
-      })
-    })
-    
-    renderSlides(hash, sliderMap[hash])
-    sliderMap[hash] = numberOfCardsToDisplay(hash)
-    renderSlides(hash, sliderMap[hash])
+      });
+    });
+
+    renderSlides(hash, sliderMap[hash]);
+    sliderMap[hash] = numberOfCardsToDisplay(hash);
+    renderSlides(hash, sliderMap[hash]);
     startAutoSlide(hash, sliderMap[hash]);
   }
-})
-
+});
 
 window.addEventListener("beforeunload", function () {
   // Clear any intervals here
-  if (intervalID) clearInterval(intervalID)
-})
+  if (intervalID) clearInterval(intervalID);
+});
 const startAutoSlide = (sliderHash, numCards) => {
   intervalID = setInterval(() => {
     reorderSlides(sliderHash, numCards, false);
   }, 8000);
 };
 
-
 var observer = new MutationObserver(function (mutations) {
   mutations.forEach(function (mutationRecord) {
-    const sliders = document.querySelectorAll(".ui.slider")
+    const sliders = document.querySelectorAll(".ui.slider");
     if (sliders === null) {
-      return
+      return;
     }
     for (let i = 0; i < sliders.length; i++) {
-      const hash = sliders[i].id
-      sliderMap[hash] = numberOfCardsToDisplay(hash)
+      const hash = sliders[i].id;
+      sliderMap[hash] = numberOfCardsToDisplay(hash);
 
-      renderSlides(hash, sliderMap[hash])
+      renderSlides(hash, sliderMap[hash]);
     }
-  })
-})
+  });
+});
 
-var elements = document.querySelectorAll(".content")
+var elements = document.querySelectorAll(".content");
 
 elements.forEach((element) =>
-  observer.observe(element, {attributes: true, attributeFilter: ["style"]})
-)
+  observer.observe(element, { attributes: true, attributeFilter: ["style"] })
+);
 
 window.onresize = () => {
-  const sliders = document.querySelectorAll(".ui.slider")
+  const sliders = document.querySelectorAll(".ui.slider");
   if (sliders === null) {
-    return
+    return;
   }
   for (let i = 0; i < sliders.length; i++) {
-    const hash = sliders[i].id
-    sliderMap[hash] = numberOfCardsToDisplay(hash)
+    const hash = sliders[i].id;
+    sliderMap[hash] = numberOfCardsToDisplay(hash);
 
-    renderSlides(hash, sliderMap[hash])
+    renderSlides(hash, sliderMap[hash]);
   }
-  
-}
-
-const debounce = (func, delay) => {
-  let timeoutId;
-  return (...args) => {
-    clearTimeout(timeoutId);
-    timeoutId = setTimeout(() => {
-      func(...args);
-    }, delay);
-  };
 };
-
-
-const debouncedReload = debounce(() => {
-  location.reload();
-}, 500);
-
-window.addEventListener("resize", function() {
-  debouncedReload();
-});


### PR DESCRIPTION
## Fix: Remove Page Reload on Window Resize

### Problem
The page was reloading continuously on every window resize event, causing poor UX and unnecessary performance overhead.

### Solution
Removed the `debounce` function and associated `location.reload()` call that was triggering full page reloads on resize events.

The existing `window.onresize` handler already handles slider resizing correctly by:
- Recalculating the number of cards to display
- Re-rendering slides dynamically
- No page reload required

### Changes
- Removed `debounce()` function
- Removed `debouncedReload()` implementation
- Removed duplicate resize event listener with `location.reload()`

### Testing
- Resize browser window and verify sliders adjust without page reload
- Verify slider cards are properly repositioned on