### PR TITLE
fix: improve slider layout and height calculation 

### DIFF
--- a/library/css/components/slider.css
+++ b/library/css/components/slider.css
@@ -7,25 +7,22 @@
 .ui.slider > div{
     max-width: 100%;
 }
+
 .ui.slider .outer-container{
-    
     overflow: hidden;
-    display: flex; /* Add flex display to outer-container */
-    align-items: center; /* Align items horizontally */
+    display: flex;
+    align-items: stretch;
 }
 
 
 .ui.slider .container{
     width: 100%; 
-   
     display: flex;
     justify-content: space-evenly;
-    
-    align-items: center;
+    align-items: stretch;
     flex-wrap: nowrap; 
 }
 .ui.slider > * > *{
-    
     margin: 10px;
 }
 .ui.slider > .left-arrow-container {

--- a/library/javascript/components/slider.js
+++ b/library/javascript/components/slider.js
@@ -32,17 +32,19 @@ const calculateMaxSliderHeight = (sliderHash) => {
 
   for (let i = 0; i < cards.length; i++) {
     const card = cards[i];
+    if (!card) continue;
 
-    const img = card.querySelector("img");
-    if (img && img.complete && img.naturalWidth) {
-      const cardWidth = card.offsetWidth || card.clientWidth || 300;
-      const aspectRatio = img.naturalHeight / img.naturalWidth;
-      const imgHeight = cardWidth * aspectRatio;
-      maxHeight = Math.max(maxHeight, imgHeight);
-    } else {
-      const cardHeight = card.offsetHeight || card.scrollHeight;
-      maxHeight = Math.max(maxHeight, cardHeight);
+    const cardHeight = card.scrollHeight || card.offsetHeight || 0;
+
+    if (cardHeight === 0) {
+      continue;
     }
+
+    const computedStyles = window.getComputedStyle(card);
+    const marginTop = parseFloat(computedStyles.marginTop) || 0;
+    const marginBottom = parseFloat(computedStyles.marginBottom) || 0;
+
+    maxHeight = Math.max(maxHeight, cardHeight + marginTop + marginBottom);
   }
 
   return maxHeight || 200;
@@ -73,9 +75,9 @@ const setFixedSliderHeight = (sliderHash) => {
   if (container) {
     Array.from(container.children).forEach((card) => {
       card.style.height = appliedHeight + "px";
-      card.style.display = card.style.display || "flex";
-      card.style.alignItems = "center";
-      card.style.justifyContent = "center";
+      card.style.minHeight = appliedHeight + "px";
+      card.style.removeProperty("align-items");
+      card.style.removeProperty("justify-content");
     });
   }
 };


### PR DESCRIPTION
Fix slider layout so cards keep a consistent height regardless of image size. Update JS to measure card content instead of image ratio and adjust CSS flex alignment to stop action buttons from overlapping. Ensures the carousel stays stable across all instances.