### PR TITLE
Title: Make StatsCard responsive on mobile

### DIFF
--- a/library/css/components/stats-card.css
+++ b/library/css/components/stats-card.css
@@ -5,5 +5,20 @@
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
+    min-width: 200px;
+    box-sizing: border-box;
+    gap: 1rem;
 }
 
+@media only screen and (max-width: 600px) {
+    .ui.stats-card {
+        min-width: 100%;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        padding-left: 1rem;
+        padding-right: 1rem;
+        gap: 0.75rem;
+        text-align: center;
+    }
+}


### PR DESCRIPTION
## Title
Make StatsCard responsive on mobile

fixes issue #348 

## Description
- Added a `min-width` to prevent cards from shrinking too much in wrapped flex layouts.
- Added a mobile breakpoint to stack the icon and text vertically under `600px`.
- Reduced mobile padding for better spacing and readability.

<img width="744" height="748" alt="Screenshot From 2026-04-21 08-20-20" src="https://github.com/user-attachments/assets/152ea234-1598-4220-b19f-f8f9365f49a1" />
<img width="744" height="748" alt="Screenshot From 2026-04-21 08-23-46" src="https://github.com/user-attachments/assets/c8abf346-590a-48d3-a60c-4dd136a4a491" />
