### PR TITLE
feat: add header for Centre for Semiconductor Design and Technology

### DIFF
--- a/library/html/center_headers/header_csdt.html
+++ b/library/html/center_headers/header_csdt.html
@@ -1,0 +1,70 @@
+<div class="ui header department">
+  <div class="ui upper-head">
+    <div class="left-container">
+      <a href="https://iitr.ac.in/Institute/Contact%20Us.html">Contact Us</a>
+      <a href="https://iitr.ac.in/support/td/">Directory</a>
+      <a href="https://iconnect.iitr.ac.in/">iConnect</a>
+      <a href="https://newwebmail.iitr.ac.in/">Webmail</a>
+    </div>
+    <div class="right-container">
+      <div class="accessibility">
+        <div class="sizechange">
+          <div class="small">
+            <img class="ui icon" data-icon="text_small" />
+          </div>
+          <div class="medium">
+            <img class="ui icon" data-icon="text_medium" />
+          </div>
+          <div class="big">
+            <img class="ui icon" data-icon="text_big" />
+          </div>
+        </div>
+
+        <div class="darkmode">
+          <div class="light-button" onclick="contrast_light()">A</div>
+          <div class="dark-button" onclick="contrast_dark()">A</div>
+        </div>
+
+        <div class="page-options">
+          <span class="language">
+            <a>&#x0939;&#x093F;&#x0928;&#x094D;&#x0926;&#x0940;</a>
+            &#9474;<a>Eng</a></span>
+        </div>
+        <div class="page-search">
+          <img class="ui icon" data-icon="search" onclick="open_search()" />
+        </div>
+      </div>
+    </div>
+
+
+  </div>
+
+  <div class="ui main-head">
+    <div id="hamBurger" class="hamburger-container">
+      <img class="ui icon" data-icon="hamburger" />
+    </div>
+    <div class="heading-section">
+      <div>
+        <div class="logo-header">
+          <div class="logo-link">
+            <a href="https://iitr.ac.in/" class="link-content">
+              <img
+                src="http://cmsredesign.channeli.in/library/assets/images/IITR_Logo.svg"
+                alt="IIT Roorkee logo"
+                width="100%"
+            /></a>
+          </div>
+
+        </div>
+        <div>
+          <div class="ui section-heading">
+            CENTRE FOR SEMICONDUCTOR DESIGN AND TECHNOLOGY
+          </div>
+          <div class="ui sub-heading">
+            INDIAN INSTITUTE OF TECHNOLOGY ROORKEE
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- Adds a new `header_csdt.html` under `library/html/center_headers/` for the **Centre for Semiconductor Design and Technology**.
- Mirrors the structure and 2-space indentation of the most recent `header_cra.html` (commit `2de7b7c`) for consistency.
- Includes the standard top-nav links, accessibility controls (font-size, dark mode, language, search), and IITR branding.

## Test plan
- [ ] Visually verify the header renders correctly when included in a page template.
- [ ] Confirm the IITR logo links to `https://iitr.ac.in/`.
- [ ] Verify the centre name and sub-heading display correctly.
- [ ] Confirm accessibility controls (font-size buttons, dark/light toggle, Hindi/English, search) are functional.
- [ ] Sanity-check responsive behaviour (hamburger appears on mobile breakpoints).

## Notes
The heading is not wrapped in an anchor tag since no dedicated CSDT centre URL was specified — this matches the pattern used in `header_cra.html`. A follow-up can add the link once the official CSDT page URL is confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)