### PR TITLE
Fix carousel mobile overlay readability

### DIFF
--- a/library/css/components/carousel.css
+++ b/library/css/components/carousel.css
@@ -175,10 +175,12 @@
 @media only screen and (max-width: 768px) {
   .ui.carousel > .ui.image.fluid > .bg-image {
     height: 40vw;
+    min-height: 200px;
   }
 
   .ui.carousel {
     height: 40vw;
+    min-height: 200px;
   }
   .ui.carousel > .image.fluid > img {
     display: block;
@@ -193,14 +195,25 @@
 
   .ui.carousel > .ui.image > .ui.section-heading {
     font-size: 20px;
-    top: 25%
+    left: 10%;
+    top: 25%;
+    width: 80%;
+    height: auto;
+    max-height: 3.2em;
+    white-space: nowrap;
+    text-overflow: ellipsis;
   }
 
   .ui.carousel > .ui.image > .ui.intro-text {
     top: 40%;
-    width: 30%;
-    height: 30%;
+    left: 10%;
+    width: 80%;
+    height: auto;
     font-size: 12px;
+    max-height: 4.5em;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 3;
   }
 
   @keyframes slide-down {
@@ -222,9 +235,27 @@
   }
 }
 
+@media only screen and (max-width: 480px) {
+  .ui.carousel,
+  .ui.carousel > .ui.image.fluid > .bg-image {
+    min-height: 200px;
+  }
+
+  .ui.carousel > .ui.image > .ui.section-heading {
+    top: 18%;
+    font-size: 16px;
+    left: 10%;
+    width: 80%;
+  }
+
+  .ui.carousel > .ui.image > .ui.intro-text {
+    display: none;
+  }
+}
+
 @media only screen and (max-width: 425px) {
   .ui.carousel > .ui.image > .ui.section-heading {
-    font-size: 12px;
-    height: 15%;
+    font-size: 14px;
+    top: 16%;
   }
 }

--- a/test/components/homepage.html
+++ b/test/components/homepage.html
@@ -678,47 +678,47 @@
         <div class="ui full-width-container gradient-blue">
             <div class="ui carousel">
                 <div class="ui image fluid">
-                    <img src="./assets/56f4da26ed956730309fa1488611ee0f13b0ac95ebb1bc9b5d210e31ff70e79c_IRD2024_11.png" alt="Alt" contentLink=""/>
+                    <img src="../assets/images/iitroorkee.jpg" alt="IIT Roorkee campus" contentLink=""/>
                     <div class="ui section-heading "></div>
                     <div class="ui intro-text "></div>
                 </div>
                 <div class="ui image fluid">
-                    <img src="./assets/56f4da26ed956730309fa1488611ee0f13b0ac95ebb1bc9b5d210e31ff70e79c_SD20241.png" alt="Alt" contentLink=""/>
+                    <img src="../assets/images/Academics-1-450x350.jpg" alt="Academics" contentLink=""/>
                     <div class="ui section-heading "></div>
                     <div class="ui intro-text "></div>
                 </div>
                 <div class="ui image fluid">
-                    <img src="./assets/56f4da26ed956730309fa1488611ee0f13b0ac95ebb1bc9b5d210e31ff70e79c_SD20244.png" alt="Alt" contentLink=""/>
+                    <img src="../assets/images/image-card-2.png" alt="Campus image card" contentLink=""/>
                     <div class="ui section-heading "></div>
                     <div class="ui intro-text "></div>
                 </div>
                 <div class="ui image fluid">
-                    <img src="./assets/56f4da26ed956730309fa1488611ee0f13b0ac95ebb1bc9b5d210e31ff70e79c_nvd1.jpg" alt="Alt" contentLink=""/>
+                    <img src="../assets/images/image-card-content.png" alt="Campus content" contentLink=""/>
                     <div class="ui section-heading "></div>
                     <div class="ui intro-text "></div>
                 </div>
                 <div class="ui image fluid">
-                    <img src="./assets/56f4da26ed956730309fa1488611ee0f13b0ac95ebb1bc9b5d210e31ff70e79c_nvd21.jpg" alt="Alt" contentLink=""/>
+                    <img src="../assets/images/image_desc_card.png" alt="Description card" contentLink=""/>
                     <div class="ui section-heading "></div>
                     <div class="ui intro-text "></div>
                 </div>
                 <div class="ui image fluid">
-                    <img src="./assets/56f4da26ed956730309fa1488611ee0f13b0ac95ebb1bc9b5d210e31ff70e79c_nvd31.jpg" alt="Alt" contentLink=""/>
+                    <img src="../assets/images/item_1.png" alt="Item one" contentLink=""/>
                     <div class="ui section-heading "></div>
                     <div class="ui intro-text "></div>
                 </div>
                 <div class="ui image fluid">
-                    <img src="./assets/56f4da26ed956730309fa1488611ee0f13b0ac95ebb1bc9b5d210e31ff70e79c_iitr175.jpg" alt="Alt" contentLink=""/>
+                    <img src="../assets/images/item_2.png" alt="Item two" contentLink=""/>
                     <div class="ui section-heading "></div>
                     <div class="ui intro-text "></div>
                 </div>
                 <div class="ui image fluid">
-                    <img src="./assets/56f4da26ed956730309fa1488611ee0f13b0ac95ebb1bc9b5d210e31ff70e79c_carousel_1.png" alt="Alt" contentLink=""/>
+                    <img src="../assets/images/completeinfo.png" alt="Complete information" contentLink=""/>
                     <div class="ui section-heading "></div>
                     <div class="ui intro-text "></div>
                 </div>
                 <div class="ui image fluid">
-                    <img src="./assets/56f4da26ed956730309fa1488611ee0f13b0ac95ebb1bc9b5d210e31ff70e79c_175years2.jpg" alt="Alt" contentLink=""/>
+                    <img src="../assets/images/g20-logo.png" alt="G20 logo" contentLink=""/>
                     <div class="ui section-heading "></div>
                     <div class="ui intro-text "></div>
                 </div>


### PR DESCRIPTION
## Summary

Improves the carousel’s mobile layout so the overlay text remains readable on smaller screens and the component does not collapse into a cramped, clipped state.

fixes issue #350 

## Changes

- Added a minimum height to the carousel and blurred background image on smaller viewports.
- Widened the overlay text area at tablet/mobile breakpoints.
- Reduced silent clipping by using ellipsis/clamp behavior for the heading and intro text.
- Hid the intro text on very small screens to avoid unreadable compression.
- Updated the homepage carousel test images to use existing local assets so the preview renders correctly.

## Verification

- Confirmed the carousel image now loads in the homepage preview.
- Verified the overlay text is readable in mobile-sized screenshots.
- Checked the carousel maintains a usable height on smaller viewports.
<img width="791" height="961" alt="Screenshot From 2026-04-22 00-29-19" src="https://github.com/user-attachments/assets/1566c615-1bc0-4b56-991c-423bb3efa685" />