### PR TITLE
fix(header): support Hindi toggle on short-url subdomains

### DIFF
--- a/library/javascript/components/header.js
+++ b/library/javascript/components/header.js
@@ -68,6 +68,12 @@ function hindi_navigate() {
         path = path.substring(0, path.length - 1)
       window.location.assign("https://" + window.location.host + path);
     }
+  } else {
+    // Short-url subdomain (e.g. ece.iitr.ac.in): use meta tag injected at publish time
+    const meta = document.querySelector('meta[name="hindi-url"]')
+    if (meta && meta.content) {
+      window.location.assign("https://iitr.ac.in" + meta.content)
+    }
   }
 }
 


### PR DESCRIPTION
## Problem

`hindi_navigate()` in `header.js` only worked when `window.location.host === "iitr.ac.in"`. On department short-url subdomains (e.g. `ece.iitr.ac.in`, `hre.iitr.ac.in`), `window.location.pathname` is just `/` — there's no path to manipulate — so clicking the Hindi button did nothing.

## Fix

Added an `else` branch: for any non-iitr.ac.in host, read the `<meta name="hindi-url">` tag and navigate to `https://iitr.ac.in` + its content.

```js
} else {
  const meta = document.querySelector('meta[name="hindi-url"]')
  if (meta && meta.content) {
    window.location.assign("https://iitr.ac.in" + meta.content)
  }
}
```

## Dependency

Requires [chakra-backend #174](https://github.com/IMGIITRoorkee/chakra-backend/pull/174) which injects the `<meta name="hindi-url">` tag at publish time. Without it, this change is a no-op on subdomains (the meta tag won't exist).

## Test plan
- [ ] Open a dept page via its shorturl subdomain (e.g. `ece.iitr.ac.in`)
- [ ] Click "हिंदी" — should navigate to the corresponding Hindi page on iitr.ac.in
- [ ] Verify clicking "हिंदी" on `iitr.ac.in/Departments/...` still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)