### PR TITLE
feat(header): add ICARS (DST CoE at Greater Noida) center header

### DIFF
--- a/Hindi/library/html/center_headers/header_icars.html
+++ b/Hindi/library/html/center_headers/header_icars.html
@@ -1,0 +1,66 @@
+<div class="ui header department">
+  <div class="ui upper-head">
+    <div class="left-container">
+      <a href="https://iitr.ac.in/Institute/Contact%20Us.html">Contact Us</a>
+      <a href="https://iitr.ac.in/support/td/">Directory</a>
+      <a href="https://iconnect.iitr.ac.in/">iConnect</a>
+      <a href="https://newwebmail.iitr.ac.in/">Webmail</a>
+    </div>
+    <div class="right-container">
+      <div class="accessibility">
+        <div class="sizechange">
+          <div class="small">
+            <img class="ui icon" data-icon="text_small" />
+          </div>
+          <div class="medium">
+            <img class="ui icon" data-icon="text_medium" />
+          </div>
+          <div class="big">
+            <img class="ui icon" data-icon="text_big" />
+          </div>
+        </div>
+
+        <div class="darkmode">
+          <div class="light-button" onclick="contrast_light()">A</div>
+          <div class="dark-button" onclick="contrast_dark()">A</div>
+        </div>
+
+        <div class="page-options">
+          <span class="language">
+            <a>&#x0939;&#x093F;&#x0928;&#x094D;&#x0926;&#x0940;</a>
+            &#9474;<a>Eng</a></span>
+        </div>
+        <div class="page-search">
+          <img class="ui icon" data-icon="search" onclick="open_search()" />
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="ui main-head">
+    <div id="hamBurger" class="hamburger-container">
+      <img class="ui icon" data-icon="hamburger" />
+    </div>
+    <div class="heading-section">
+      <div class="logo-header">
+        <div class="logo-link">
+          <a href="https://iitr.ac.in/Hindi/" class="link-content">
+            <img
+              src="http://cmsredesign.channeli.in/library/assets/images/IITR_Logo.svg"
+              alt="IIT Roorkee logo"
+              width="100%"
+          /></a>
+        </div>
+
+      </div>
+      <div>
+        <div class="ui section-heading">
+          आईकार्स (डीएसटी सीओई, ग्रेटर नोएडा)
+        </div>
+        <div class="ui sub-heading">
+          भारतीय प्रौद्योगिकी संस्थान रुड़की
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/library/html/center_headers/header_icars.html
+++ b/library/html/center_headers/header_icars.html
@@ -1,0 +1,68 @@
+<div class="ui header department">
+  <div class="ui upper-head">
+    <div class="left-container">
+      <a href="https://iitr.ac.in/Institute/Contact%20Us.html">Contact Us</a>
+      <a href="https://iitr.ac.in/support/td/">Directory</a>
+      <a href="https://iconnect.iitr.ac.in/">iConnect</a>
+      <a href="https://newwebmail.iitr.ac.in/">Webmail</a>
+    </div>
+    <div class="right-container">
+      <div class="accessibility">
+        <div class="sizechange">
+          <div class="small">
+            <img class="ui icon" data-icon="text_small" />
+          </div>
+          <div class="medium">
+            <img class="ui icon" data-icon="text_medium" />
+          </div>
+          <div class="big">
+            <img class="ui icon" data-icon="text_big" />
+          </div>
+        </div>
+
+        <div class="darkmode">
+          <div class="light-button" onclick="contrast_light()">A</div>
+          <div class="dark-button" onclick="contrast_dark()">A</div>
+        </div>
+
+        <div class="page-options">
+          <span class="language">
+            <a>&#x0939;&#x093F;&#x0928;&#x094D;&#x0926;&#x0940;</a>
+            &#9474;<a>Eng</a></span>
+        </div>
+        <div class="page-search">
+          <img class="ui icon" data-icon="search" onclick="open_search()" />
+        </div>
+      </div>
+    </div>
+
+
+  </div>
+
+  <div class="ui main-head">
+    <div id="hamBurger" class="hamburger-container">
+      <img class="ui icon" data-icon="hamburger" />
+    </div>
+    <div class="heading-section">
+      <div>
+        <div class="logo-header">
+          <div class="logo-link">
+            <a href="https://iitr.ac.in/" class="link-content">
+              <img
+                src="http://cmsredesign.channeli.in/library/assets/images/IITR_Logo.svg"
+                alt="IIT Roorkee logo"
+                width="100%"
+            /></a>
+          </div>
+
+        </div>
+        <div>
+          <div class="ui section-heading">ICARS (DST CoE AT GREATER NOIDA)</div>
+          <div class="ui sub-heading">
+            INDIAN INSTITUTE OF TECHNOLOGY ROORKEE
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- Add `library/html/center_headers/header_icars.html` — English header for ICARS (DST CoE at Greater Noida)
- Add `Hindi/library/html/center_headers/header_icars.html` — Hindi equivalent

Both follow the same structure as existing center headers (ICC, Noida), using the IIT Roorkee logo with section-heading + sub-heading layout.

## Test plan
- [ ] Verify English header renders correctly with IITR logo, "ICARS (DST CoE AT GREATER NOIDA)" heading, and "INDIAN INSTITUTE OF TECHNOLOGY ROORKEE" sub-heading
- [ ] Verify Hindi header renders correctly with Devanagari text

🤖 Generated with [Claude Code](https://claude.com/claude-code)