### PR TITLE
chore(security): ignore .env files at any depth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ env/
 *.pyc
 
 *.DS_Store
+# Secrets: match any .env anywhere. The negation guards committed stencil
+# templates if this pattern is ever widened to *.env.
+.env
+.env.*
+!*stencil*


### PR DESCRIPTION
## Summary

A bare `.env` was not ignored in this repo. That is the mechanism behind two separate OAuth client secrets reaching git history in this project — deletion from HEAD does not remove them from the object store, so each one needs rotating rather than just deleting.

The rules now match `.env` and `.env.*` at any depth. The negation keeps committed stencil templates tracked if the pattern is ever widened to `*.env`.

This is prevention only; it does not remediate anything already in history.

## Test plan

- [x] `git check-ignore` confirms `.env`, `.env.local` and `sub/.env` are all matched
- [x] Confirmed no currently tracked file becomes ignored by these rules