### PR TITLE
fix(service): compare webhook signatures in constant time

### DIFF
--- a/.github/workflows/service-quality.yml
+++ b/.github/workflows/service-quality.yml
@@ -2,7 +2,6 @@ name: Service Quality Gate
 
 on:
   pull_request:
-    branches: [staging]
     paths:
       - 'service/**'
       - '.github/workflows/service-quality.yml'

--- a/.github/workflows/service-quality.yml
+++ b/.github/workflows/service-quality.yml
@@ -1,0 +1,33 @@
+name: Service Quality Gate
+
+on:
+  pull_request:
+    branches: [staging]
+    paths:
+      - 'service/**'
+      - '.github/workflows/service-quality.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  python:
+    name: python
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      # service/requirements.txt pins PyYAML 5.4.1, which does not build on
+      # current Python; the signature check is stdlib-only, so install unpinned.
+      - name: Install runtime imports
+        run: pip install flask pyyaml
+
+      - name: Webhook signature checks
+        run: python3 service/scripts/test_github.py

--- a/service/scripts/github.py
+++ b/service/scripts/github.py
@@ -1,12 +1,15 @@
 from flask import Flask, request
 import io
+import os
 import yaml
 import hmac
 import hashlib
 import json
 import subprocess
 
-with io.open('../config/config.yml', 'r') as stream:
+CONFIG_PATH = os.environ.get('CHAKRA_LIBRARY_CONFIG', '../config/config.yml')
+
+with io.open(CONFIG_PATH, 'r') as stream:
     try:
         CONFIG = yaml.safe_load(stream)
     except yaml.YAMLError as exc:
@@ -20,12 +23,21 @@ ssh_url = CONFIG['GITHUB']['SSH_URL']
 
 app = Flask(__name__)
 
+
+def signature_matches(shared_secret, body, headers):
+    """Compare the webhook signature in constant time, preferring SHA-256 over the deprecated SHA-1 header."""
+    sent = headers.get('X-Hub-Signature-256')
+    if sent:
+        expected = 'sha256=' + hmac.new(shared_secret.encode(), body, hashlib.sha256).hexdigest()
+    else:
+        sent = headers.get('X-Hub-Signature') or ''
+        expected = 'sha1=' + hmac.new(shared_secret.encode(), body, hashlib.sha1).hexdigest()
+    return hmac.compare_digest(expected, sent)
+
+
 @app.route('/', methods=['POST'])
 def server():
-    encoded_secret = secret.encode()
-    signature = 'sha1=' + hmac.new(encoded_secret, request.get_data(), hashlib.sha1).hexdigest()
-
-    if signature == request.headers.get('X-Hub-Signature'):
+    if signature_matches(secret, request.get_data(), request.headers):
         payload = request.form.get("payload")
         payload = json.loads(payload)
         

--- a/service/scripts/test_github.py
+++ b/service/scripts/test_github.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Checks for the webhook signature comparison. Run: python3 service/scripts/test_github.py"""
+
+import hashlib
+import hmac
+import os
+import sys
+import tempfile
+
+SECRET = 'topsecret'
+BODY = b'{"ref": "refs/heads/staging"}'
+
+CONFIG = """GITHUB:
+  REPOSITORY: /tmp/repo
+  SECRET: topsecret
+  STAGING_BRANCH: staging
+  SSH_URL: git@github.com:IMGIITRoorkee/chakra-library.git
+"""
+
+
+def load_module():
+    handle = tempfile.NamedTemporaryFile('w', suffix='.yml', delete=False)
+    handle.write(CONFIG)
+    handle.close()
+    os.environ['CHAKRA_LIBRARY_CONFIG'] = handle.name
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    import github
+
+    return github
+
+
+def sign(algorithm, prefix, body=BODY, secret=SECRET):
+    return prefix + hmac.new(secret.encode(), body, algorithm).hexdigest()
+
+
+def main():
+    github = load_module()
+    matches = github.signature_matches
+    sha1 = sign(hashlib.sha1, 'sha1=')
+    sha256 = sign(hashlib.sha256, 'sha256=')
+
+    assert matches(SECRET, BODY, {'X-Hub-Signature': sha1})
+    assert matches(SECRET, BODY, {'X-Hub-Signature-256': sha256})
+
+    # The SHA-256 header wins when present, so a good SHA-1 must not rescue a bad SHA-256.
+    assert not matches(SECRET, BODY, {'X-Hub-Signature-256': 'sha256=' + '0' * 64,
+                                      'X-Hub-Signature': sha1})
+
+    assert not matches(SECRET, BODY, {'X-Hub-Signature': 'sha1=' + '0' * 40})
+    assert not matches(SECRET, BODY, {'X-Hub-Signature': sha1[:-1]})
+    assert not matches(SECRET, b'tampered', {'X-Hub-Signature': sha1})
+    assert not matches('wrongsecret', BODY, {'X-Hub-Signature': sha1})
+    assert not matches(SECRET, BODY, {})
+
+    print('signature_matches: 8 checks pass')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

`service/scripts/github.py` receives GitHub webhooks and runs `git pull` on the deploy host when the signature validates. It compared the computed HMAC to the header with `==`:

```python
signature = 'sha1=' + hmac.new(encoded_secret, request.get_data(), hashlib.sha1).hexdigest()
if signature == request.headers.get('X-Hub-Signature'):
```

`==` on `str` short-circuits at the first differing byte. Because this secret authorizes code deployment, the comparison is now `hmac.compare_digest`.

Two supporting changes:

- The receiver only accepted `X-Hub-Signature`, the SHA-1 header GitHub deprecated in 2019. It now prefers `X-Hub-Signature-256` when present and falls back to SHA-1 otherwise, so this can merge without anyone having to reconfigure the webhook first. Once the webhook is switched to SHA-256, the SHA-1 branch can be deleted.
- The config path now comes from `CHAKRA_LIBRARY_CONFIG` and defaults to the previous `../config/config.yml`, so the module is importable without a config file on disk. Deployed behaviour is unchanged when the variable is unset.

`chakra-core/app.py` already uses `hmac.compare_digest` for the same job, so this brings the two services in line.

## Scope

What this does **not** do, deliberately:

- It does not delete the service. The deploy documentation says a Jenkins job, `canvas-chakra-library`, performs the pull, so this Flask receiver may be superseded and unused. Someone with server access should confirm whether it is running. If it is dead, deleting it removes the surface entirely and this fix becomes moot - but that is a call to make from evidence, not from an assumption.
- It does not address the other rough edges in the same file: a non-push event raises `KeyError` on `payload["ref"]`, a webhook configured as `application/json` yields `None` from `request.form.get("payload")`, and `Popen(...).communicate()` returns `(None, None)` because no pipes are configured, so a failed pull still returns `200 OK`. Those are correctness issues rather than security ones and belong in their own change.

## Test plan

`service/scripts/test_github.py` asserts the signature behaviour, and `.github/workflows/service-quality.yml` runs it on pull requests touching `service/`.

- [x] 8 checks pass: valid SHA-1 accepted, valid SHA-256 accepted, a valid SHA-1 alongside a wrong SHA-256 rejected (SHA-256 takes precedence), wrong signature rejected, truncated signature rejected, tampered body rejected, wrong secret rejected, missing headers rejected
- [x] Confirmed the test fails when the fix regresses: making the code ignore `X-Hub-Signature-256` produces an `AssertionError`
- [x] The workflow parses as valid YAML

Note on what the test can and cannot prove: it covers the behavioural surface, but constant-time comparison is not observable from a functional test. That property rests on `hmac.compare_digest` being used at all, which is a review matter rather than something CI can assert.

CI installs `flask` and `pyyaml` unpinned rather than from `service/requirements.txt`, which pins PyYAML 5.4.1 and does not build on current Python. The signature logic is stdlib-only. Refreshing those pins is a separate change.