### PR TITLE
fix(a11y): restore keyboard focus visibility

### DIFF
--- a/library/css/globals/reset.css
+++ b/library/css/globals/reset.css
@@ -121,3 +121,8 @@ table {
 select {
   font-family: var(--font-nunito-sans);
 }
+/* Keyboard focus ring, contrasts against both light and dark variable sets */
+:focus-visible {
+  outline: 2px solid #e8590c;
+  outline-offset: 2px;
+}

--- a/library/javascript/components/search.js
+++ b/library/javascript/components/search.js
@@ -35,10 +35,6 @@ function open_search() {
   go_back.style.cursor = 'pointer';
   go_back.style.marginLeft = '15rem';
   search_modal.appendChild(go_back);
-  input_tag.addEventListener('focus', function () {
-    this.style.border = 'none';
-    this.style.outline = 'none';
-  });
   search_div.appendChild(input_tag);
   input_parent.appendChild(search_div);
   search_modal.appendChild(input_parent);


### PR DESCRIPTION
## Summary

- Removed the `focus` listener in `library/javascript/components/search.js` that set `border: none` and `outline: none` on the search input, which erased its own focus ring.
- Added a `:focus-visible` rule to `library/css/globals/reset.css` giving every interactive element a visible outline. `:focus-visible` (rather than `:focus`) means the ring only shows for keyboard navigation, not mouse clicks. The color (`#e8590c`) was chosen for sufficient contrast against both a white page background and the site's existing dark surfaces (e.g. the search modal's `#313131` backdrop), since the `.dark` theme only swaps CSS variables and does not itself darken the page background.

Closes #378

## Test plan

- `grep -nE ':focus|outline' -r library/css Hindi` confirmed no pre-existing focus/outline rules before this change.
- `git ls-files -z '*.js' '*.sh' '*.py' | xargs -0 python3 .github/scripts/comment_lint.py` passes.
- `node --check` passes on all files under `library/javascript`.
